### PR TITLE
JCB card number lengths are incorrectly reported invalid

### DIFF
--- a/jquery.creditCardValidator.coffee
+++ b/jquery.creditCardValidator.coffee
@@ -41,7 +41,7 @@ $.fn.validateCreditCard = (callback) ->
         {
             name: 'jcb'
             pattern: /^35(2[89]|[3-8][0-9])/
-            valid_length: 16
+            valid_length: [ 16 ]
         }
         {
             name: 'laser'

--- a/jquery.creditCardValidator.js
+++ b/jquery.creditCardValidator.js
@@ -43,7 +43,7 @@ Mountain View, California, 94041, USA.
       }, {
         name: 'jcb',
         pattern: /^35(2[89]|[3-8][0-9])/,
-        valid_length: 16
+        valid_length: [16]
       }, {
         name: 'laser',
         pattern: /^(6304|630[69]|6771)/,


### PR DESCRIPTION
As the title states, JCB card number lengths are always reported to be invalid, even when the length is correct (16). This is caused by calling `Array.prototype.indexOf` on a number, rather than an array.
