### PR TITLE
Remove Diners Club US & CA card type (issue #2)

### DIFF
--- a/jquery.creditCardValidator.coffee
+++ b/jquery.creditCardValidator.coffee
@@ -34,11 +34,6 @@ $.fn.validateCreditCard = (callback) ->
             valid_length: [ 14 ]
         }
         {
-            name: 'diners_club_us_and_ca'
-            pattern: /^5[45]/
-            valid_length: [ 16 ]
-        }
-        {
             name: 'jcb'
             pattern: /^35(2[89]|[3-8][0-9])/
             valid_length: [ 16 ]

--- a/jquery.creditCardValidator.js
+++ b/jquery.creditCardValidator.js
@@ -36,10 +36,6 @@ Mountain View, California, 94041, USA.
         pattern: /^36/,
         valid_length: [14]
       }, {
-        name: 'diners_club_us_and_ca',
-        pattern: /^5[45]/,
-        valid_length: [16]
-      }, {
         name: 'jcb',
         pattern: /^35(2[89]|[3-8][0-9])/,
         valid_length: [16]


### PR DESCRIPTION
I have removed the Diners Club US & CA card type as these cards have been treated as MasterCards since 2004.

I know you were going to change this too, so if you have already feel free to ignore this. (I am in the middle of developing a site utilising the plugin so thought I'd just quickly make the change).
