### PR TITLE
Removed the Diners Club US & CA from docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,6 @@
             <li>American Express &mdash; <code>amex</code></li>
             <li>Diners Club Carte Blanche &mdash; <code>diners_club_carte_blanche</code></li>
             <li>Diners Club International &mdash; <code>diners_club_international</code></li>
-            <li>Diners Club United States &amp; Canada &mdash; <code>diners_club_us_and_ca</code></li>
             <li>Discover Card &mdash; <code>discover</code></li>
             <li>JCB &mdash; <code>jcb</code></li>
             <li>Laser &mdash; <code>laser</code></li>


### PR DESCRIPTION
I've removed the reference to Diners Club US & CA cards in the documentation since it's now been removed from the code.
