### PR TITLE
Namespaced events

### DIFF
--- a/jquery.creditCardValidator.coffee
+++ b/jquery.creditCardValidator.coffee
@@ -110,6 +110,8 @@ $.fn.validateCreditCard = (callback) ->
         $(this).trigger 'creditcard.validation',validationResult
         if card_type and luhn_valid and length_valid
             $(this).trigger 'valid.creditcard.validation',validationResult
+        else
+            $(this).trigger 'invalid.creditcard.validation',validationResult
         callback validationResult
 
     validate = ->

--- a/jquery.creditCardValidator.js
+++ b/jquery.creditCardValidator.js
@@ -115,6 +115,8 @@ Mountain View, California, 94041, USA.
       $(this).trigger('creditcard.validation', validationResult);
       if (card_type && luhn_valid && length_valid) {
         $(this).trigger('valid.creditcard.validation', validationResult);
+      } else {
+        $(this).trigger('invalid.creditcard.validation', validationResult);
       }
       return callback(validationResult);
     };


### PR DESCRIPTION
Closes #9.
Added `creditcard.validation` that fires on each validation attempt.
Added `valid.creditcard.validation` that fires on only successful validations.
Each event maintains the `<input>` element as context, so you can attached remote event listeners and still get a reference to the element via `this`.
