### PR TITLE
Validation should only run when selector is found

### DIFF
--- a/jquery.creditCardValidator.coffee
+++ b/jquery.creditCardValidator.coffee
@@ -125,7 +125,6 @@ $.fn.validateCreditCard = (callback) ->
     )
 
     # run validation straight away in case the card number is prefilled
-    if this.length > 0
-        validate.call this
+    validate.call this unless this.length is 0
 
     this

--- a/jquery.creditCardValidator.js
+++ b/jquery.creditCardValidator.js
@@ -127,7 +127,7 @@ Mountain View, California, 94041, USA.
     this.bind('keyup', function() {
       return validate.call(this);
     });
-    if (this.length > 0) {
+    if (this.length !== 0) {
       validate.call(this);
     }
     return this;


### PR DESCRIPTION
We're using this awesome script on a Rails site where all our JS is minified and loaded on all pages, including pages which don't display a credit card form. This was causing a JS error on those other pages because the validate function was being called on an empty jQuery object (since nothing on the page matched the selector for the credit card number input). I added a check to make sure the selector was actually matched on the page before running the validate function, to avoid this error.
