### PR TITLE
Remove extraneous single-quote in basic usage example

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@
     {
         alert('CC type: ' + result.card_type.name
           + '\nLength validation: ' + result.length_valid
-          + '\nLuhn validation: ' + result.luhn_valid');
+          + '\nLuhn validation: ' + result.luhn_valid);
     });</code></pre>
 
                 <p>Or with <code class="language-javascript">options</code> specified:</p>


### PR DESCRIPTION
Just cleaning up some example code.
