### PR TITLE
Allowing Visa cards with length = 13

### DIFF
--- a/jquery.creditCardValidator.coffee
+++ b/jquery.creditCardValidator.coffee
@@ -51,7 +51,7 @@ $.fn.validateCreditCard = (callback, options) ->
         {
             name: 'visa'
             pattern: /^4/
-            valid_length: [ 16 ]
+            valid_length: [ 13, 16 ]
         }
         {
             name: 'mastercard'


### PR DESCRIPTION
"Whilst the vast majority of Visa's account ranges describe 16 digit card numbers there are still a few (40 as of 11 Dec. 2013) account ranges dedicated to 13 digit PANs and several (439 as of 11 Dec. 2013) account ranges where the issuer can mix 13 and 16 digit card numbers. Visa's VPay brand can specify PAN lengths from 13 to 19 digits and so card numbers of more than 16 digits are now being seen." -- http://en.wikipedia.org/wiki/Bank_card_number

Also, the test Visa card numbers for Authorize.Net are 13 digits long: http://developer.authorize.net/faqs/#testccnumbers