### PR TITLE
Validate by Luhn even if card type is not supported yet

### DIFF
--- a/jquery.creditCardValidator.coffee
+++ b/jquery.creditCardValidator.coffee
@@ -145,11 +145,10 @@ $.fn.validateCreditCard = (callback, options) ->
 
     validate_number = (number) ->
         card_type = get_card_type number
-        luhn_valid = false
+        luhn_valid = is_valid_luhn number
         length_valid = false
 
         if card_type?
-            luhn_valid = is_valid_luhn number
             length_valid = is_valid_length number, card_type
 
         card_type: card_type


### PR DESCRIPTION
Now we firstly check card type and only then run a Luhn validation. In that case we don't support most of valid cards of unknown for us vendors. In this case we don't support most of valid cards AND response that that cards are NOT valid by Luhn, but they actually are.

My suggestion is return correct response independently of card type.

STR:
Try to validate Australian BankCard 5610591081018250.

Expected result:
`Object {card_type: null, valid: false, luhn_valid: true, length_valid: false}`
(plugin doesn't support Australian BankCard type, so card_type might be null)

Actual result:
`Object {card_type: null, valid: false, luhn_valid: false, length_valid: false}`

The rest of unsupported cards, but valid by Luhn:
- 0604910072459324 (Maestro)
- 38520000023237 (Diners Club)
- 4222222222222 (Visa)
- 5019717010103742 (Dankort (PBS))
- 6331101999990016 (Switch/Solo (Paymentech))
