### PR TITLE
new MasterCard IINs

### DIFF
--- a/jquery.creditCardValidator.coffee
+++ b/jquery.creditCardValidator.coffee
@@ -63,7 +63,7 @@ $.fn.validateCreditCard = (callback, options) ->
         }
         {
             name: 'mastercard'
-            pattern: /^5[1-5]/
+            pattern: /^(5[1-5]|2[2-7])/
             valid_length: [ 16 ]
         }
         {


### PR DESCRIPTION
Added the rough pattern to recognize the new MasterCard IINs, to be available from 2017. See also https://en.wikipedia.org/wiki/Payment_card_number and https://www.mastercard.us/en-us/issuers/get-support/2-series-bin-expansion.html