### PR TITLE
Broke out union pay as new credit card type

### DIFF
--- a/jquery.creditCardValidator.coffee
+++ b/jquery.creditCardValidator.coffee
@@ -68,8 +68,13 @@ $.fn.validateCreditCard = (callback, options) ->
         }
         {
             name: 'discover'
-            range: '6011, 622126-622925, 644-649, 65'
+            range: '6011, 65'
             valid_length: [ 16 ]
+        }
+        {
+            name: 'union_pay'
+            range: '622126-622925, 644-649, 6282-6288'
+            valid_length: [ 16..19 ]
         }
         {
             name: 'dankort'


### PR DESCRIPTION
I think it makes sense to break China Union Pay out into its own card type. This way you can give it a specific icon.